### PR TITLE
Loosen `has_scope` dependency to fix Rails 5+

### DIFF
--- a/activeadmin-ajax_filter.gemspec
+++ b/activeadmin-ajax_filter.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rails', '>= 4'
   gem.add_dependency 'coffee-rails', '>= 4.1.0'
   gem.add_dependency 'selectize-rails', '>= 0.11.2'
-  gem.add_dependency 'has_scope', '~> 0.6.0' # Force Ruby 2.1.5 support
+  gem.add_dependency 'has_scope', '>= 0.6.0' # Force Ruby 2.1.5 support
   gem.add_development_dependency 'bundler', '~> 1.10'
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3.3', '>= 3.3.0'


### PR DESCRIPTION
`has_scope` 0.7.0 (or newer) is needed for Rails 5 compatibility.

This should fix https://github.com/holyketzer/activeadmin-ajax_filter/issues/21